### PR TITLE
Make the viewport and children expand to fill

### DIFF
--- a/addons/Imposter/imposter.gd
+++ b/addons/Imposter/imposter.gd
@@ -3,14 +3,13 @@ extends PanelContainer
 @onready var Single = preload("res://addons/Imposter/imposter/scenes/single_bake.tscn")
 @onready var Batch = preload("res://addons/Imposter/imposter/scenes/batch_bake.tscn")
 @onready var subs:TabContainer = $TabContainer
+
 func _ready():
 	subs.use_hidden_tabs_for_min_size=true
 	subs.drag_to_rearrange_enabled=true
-	subs.custom_minimum_size=Vector2i(2048,600)
-	subs.set_anchors_preset(Control.PRESET_FULL_RECT)
+	var view_size: Vector2i = EditorInterface.get_editor_viewport_2d().size
+	subs.custom_minimum_size = view_size - (Vector2i(view_size*0.1))
 	var single_bake = Single.instantiate()
 	subs.add_child(single_bake)
 	var batch_bake = Batch.instantiate()
 	subs.add_child(batch_bake)
-
-	

--- a/addons/Imposter/imposter.tscn
+++ b/addons/Imposter/imposter.tscn
@@ -15,7 +15,6 @@ script = ExtResource("1_op0f2")
 
 [node name="TabContainer" type="TabContainer" parent="."]
 clip_contents = true
-custom_minimum_size = Vector2(799, 200)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/addons/Imposter/imposter.tscn
+++ b/addons/Imposter/imposter.tscn
@@ -3,10 +3,22 @@
 [ext_resource type="Script" path="res://addons/Imposter/imposter.gd" id="1_op0f2"]
 
 [node name="imposter" type="PanelContainer"]
+clip_contents = true
+custom_minimum_size = Vector2(512, 200)
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 331.0
+grow_horizontal = 2
+size_flags_horizontal = 3
+size_flags_vertical = 10
 script = ExtResource("1_op0f2")
 
 [node name="TabContainer" type="TabContainer" parent="."]
-custom_minimum_size = Vector2(2048, 512)
+clip_contents = true
+custom_minimum_size = Vector2(799, 200)
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+current_tab = 0
 drag_to_rearrange_enabled = true
 use_hidden_tabs_for_min_size = true

--- a/addons/Imposter/imposter/scenes/batch_bake.tscn
+++ b/addons/Imposter/imposter/scenes/batch_bake.tscn
@@ -34,9 +34,9 @@ layout_mode = 2
 size_flags_vertical = 0
 
 [node name="GridContainer" type="VBoxContainer" parent="HSplitContainer/Selects"]
-custom_minimum_size = Vector2(300, 300)
 layout_mode = 2
 size_flags_horizontal = 3
+size_flags_vertical = 3
 
 [node name="SelectLabel" type="Label" parent="HSplitContainer/Selects/GridContainer"]
 layout_mode = 2

--- a/addons/Imposter/imposter/scenes/batch_bake.tscn
+++ b/addons/Imposter/imposter/scenes/batch_bake.tscn
@@ -12,47 +12,51 @@ ssil_enabled = true
 [sub_resource type="World3D" id="World3D_cu3oi"]
 environment = SubResource("Environment_w63d6")
 
-[node name="batch" type="Control"]
-layout_mode = 3
-anchors_preset = 15
+[node name="batch" type="ScrollContainer"]
+custom_minimum_size = Vector2(400, 300)
+anchors_preset = 10
 anchor_right = 1.0
-anchor_bottom = 1.0
+offset_bottom = 8.0
 grow_horizontal = 2
-grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource("1_4en8b")
 
 [node name="HSplitContainer" type="HSplitContainer" parent="."]
-custom_minimum_size = Vector2(0, 600)
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
+custom_minimum_size = Vector2(512, 300)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 
 [node name="Selects" type="ScrollContainer" parent="HSplitContainer"]
-custom_minimum_size = Vector2(512, 0)
+custom_minimum_size = Vector2(300, 300)
 layout_mode = 2
-horizontal_scroll_mode = 0
+size_flags_vertical = 0
 
 [node name="GridContainer" type="VBoxContainer" parent="HSplitContainer/Selects"]
-custom_minimum_size = Vector2(100, 0)
+custom_minimum_size = Vector2(300, 300)
 layout_mode = 2
+size_flags_horizontal = 3
 
 [node name="SelectLabel" type="Label" parent="HSplitContainer/Selects/GridContainer"]
 layout_mode = 2
 text = "model dir"
 
 [node name="SelectDir" type="HBoxContainer" parent="HSplitContainer/Selects/GridContainer"]
-custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 
 [node name="LineEdit" type="LineEdit" parent="HSplitContainer/Selects/GridContainer/SelectDir"]
-custom_minimum_size = Vector2(400, 0)
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
 placeholder_text = "Select model dir"
 clear_button_enabled = true
 
 [node name="SelectBut" type="TextureButton" parent="HSplitContainer/Selects/GridContainer/SelectDir"]
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
+size_flags_horizontal = 0
 texture_normal = ExtResource("2_peyw6")
 texture_pressed = ExtResource("3_kmocx")
 ignore_texture_size = true
@@ -67,8 +71,9 @@ custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 
 [node name="LineEdit" type="LineEdit" parent="HSplitContainer/Selects/GridContainer/SaveDir"]
-custom_minimum_size = Vector2(400, 0)
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
+size_flags_horizontal = 3
 placeholder_text = "Select save dir"
 clear_button_enabled = true
 
@@ -121,6 +126,7 @@ layout_mode = 2
 
 [node name="Label" type="Label" parent="HSplitContainer/Selects/GridContainer/HBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 3
 text = "dilatate bake distance"
 
 [node name="DilatateSpin" type="SpinBox" parent="HSplitContainer/Selects/GridContainer/HBoxContainer"]
@@ -129,28 +135,40 @@ max_value = 64.0
 value = 32.0
 
 [node name="PreviewNode" type="VBoxContainer" parent="HSplitContainer"]
+clip_contents = true
 layout_mode = 2
+size_flags_horizontal = 3
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HSplitContainer/PreviewNode"]
+clip_contents = true
 layout_mode = 2
 
 [node name="ProgressBar" type="ProgressBar" parent="HSplitContainer/PreviewNode/HBoxContainer"]
-custom_minimum_size = Vector2(1024, 0)
+custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
 
 [node name="Generate" type="Button" parent="HSplitContainer/PreviewNode/HBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 4
 text = "generate"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="HSplitContainer/PreviewNode"]
-custom_minimum_size = Vector2(512, 512)
 layout_mode = 2
+size_flags_vertical = 3
 
 [node name="BoxContainer" type="BoxContainer" parent="HSplitContainer/PreviewNode/ScrollContainer"]
+clip_contents = true
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 
 [node name="SubViewportContainer" type="SubViewportContainer" parent="HSplitContainer/PreviewNode/ScrollContainer/BoxContainer"]
+clip_contents = true
 layout_mode = 2
+size_flags_horizontal = 3
 
 [node name="SubViewport" type="SubViewport" parent="HSplitContainer/PreviewNode/ScrollContainer/BoxContainer/SubViewportContainer"]
 world_3d = SubResource("World3D_cu3oi")
@@ -163,14 +181,14 @@ render_target_update_mode = 4
 title = "Open a Directory"
 initial_position = 4
 size = Vector2i(800, 600)
-ok_button_text = "选择当前文件夹"
+ok_button_text = "Select Current Folder"
 file_mode = 2
 
 [node name="SaveFileDialog" type="FileDialog" parent="."]
 title = "Open a Directory"
 initial_position = 4
 size = Vector2i(800, 600)
-ok_button_text = "选择当前文件夹"
+ok_button_text = "Select Current Folder"
 file_mode = 2
 
 [node name="AcceptDialog" type="AcceptDialog" parent="."]

--- a/addons/Imposter/imposter/scenes/single_bake.tscn
+++ b/addons/Imposter/imposter/scenes/single_bake.tscn
@@ -34,9 +34,9 @@ custom_minimum_size = Vector2(300, 300)
 layout_mode = 2
 
 [node name="GridContainer" type="VBoxContainer" parent="HSplitContainer/Selects"]
-custom_minimum_size = Vector2(200, 300)
 layout_mode = 2
 size_flags_horizontal = 3
+size_flags_vertical = 3
 
 [node name="Process" type="Button" parent="HSplitContainer/Selects/GridContainer"]
 layout_mode = 2

--- a/addons/Imposter/imposter/scenes/single_bake.tscn
+++ b/addons/Imposter/imposter/scenes/single_bake.tscn
@@ -12,24 +12,31 @@ ssil_enabled = true
 [sub_resource type="World3D" id="World3D_flfsy"]
 environment = SubResource("Environment_6wwrl")
 
-[node name="single" type="Control"]
-layout_mode = 3
-anchors_preset = 0
+[node name="single" type="ScrollContainer"]
+custom_minimum_size = Vector2(400, 300)
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 300.0
+grow_horizontal = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource("1_0ba82")
 
 [node name="HSplitContainer" type="HSplitContainer" parent="."]
-layout_mode = 0
-offset_right = 40.0
-offset_bottom = 40.0
+clip_contents = true
+custom_minimum_size = Vector2(512, 300)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 
 [node name="Selects" type="ScrollContainer" parent="HSplitContainer"]
-custom_minimum_size = Vector2(512, 0)
+custom_minimum_size = Vector2(300, 300)
 layout_mode = 2
-horizontal_scroll_mode = 0
 
 [node name="GridContainer" type="VBoxContainer" parent="HSplitContainer/Selects"]
-custom_minimum_size = Vector2(100, 0)
+custom_minimum_size = Vector2(200, 300)
 layout_mode = 2
+size_flags_horizontal = 3
 
 [node name="Process" type="Button" parent="HSplitContainer/Selects/GridContainer"]
 layout_mode = 2
@@ -56,14 +63,16 @@ text = "save dir"
 layout_mode = 2
 
 [node name="LineEdit" type="LineEdit" parent="HSplitContainer/Selects/GridContainer/SaveDir"]
-custom_minimum_size = Vector2(400, 0)
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
+size_flags_horizontal = 3
 placeholder_text = "Select save dir"
 clear_button_enabled = true
 
 [node name="SaveBut" type="TextureButton" parent="HSplitContainer/Selects/GridContainer/SaveDir"]
 custom_minimum_size = Vector2(25, 25)
 layout_mode = 2
+size_flags_horizontal = 0
 texture_normal = ExtResource("2_uj55j")
 texture_pressed = ExtResource("3_lu3jy")
 ignore_texture_size = true
@@ -75,10 +84,12 @@ text = "full sphere"
 
 [node name="ShadowBut" type="CheckButton" parent="HSplitContainer/Selects/GridContainer"]
 layout_mode = 2
+size_flags_horizontal = 5
 text = "create shadow mesh"
 
 [node name="FramesSize" type="HBoxContainer" parent="HSplitContainer/Selects/GridContainer"]
 layout_mode = 2
+size_flags_horizontal = 5
 
 [node name="Label" type="Label" parent="HSplitContainer/Selects/GridContainer/FramesSize"]
 layout_mode = 2
@@ -93,6 +104,7 @@ value = 16.0
 
 [node name="Resolution" type="HBoxContainer" parent="HSplitContainer/Selects/GridContainer"]
 layout_mode = 2
+size_flags_horizontal = 5
 
 [node name="Label" type="Label" parent="HSplitContainer/Selects/GridContainer/Resolution"]
 layout_mode = 2
@@ -107,6 +119,7 @@ value = 1024.0
 
 [node name="Dilatate" type="HBoxContainer" parent="HSplitContainer/Selects/GridContainer"]
 layout_mode = 2
+size_flags_horizontal = 5
 
 [node name="Label" type="Label" parent="HSplitContainer/Selects/GridContainer/Dilatate"]
 layout_mode = 2
@@ -119,29 +132,41 @@ max_value = 64.0
 value = 32.0
 
 [node name="PreviewNodes" type="VBoxContainer" parent="HSplitContainer"]
+clip_contents = true
+custom_minimum_size = Vector2(400, 300)
 layout_mode = 2
+size_flags_horizontal = 3
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HSplitContainer/PreviewNodes"]
+clip_contents = true
+custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 
 [node name="ProgressBar" type="ProgressBar" parent="HSplitContainer/PreviewNodes/HBoxContainer"]
-custom_minimum_size = Vector2(1024, 0)
+clip_contents = true
+custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
 
 [node name="Generate" type="Button" parent="HSplitContainer/PreviewNodes/HBoxContainer"]
 layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 4
 text = "generate"
 
 [node name="Preview" type="ScrollContainer" parent="HSplitContainer/PreviewNodes"]
-custom_minimum_size = Vector2(512, 512)
 layout_mode = 2
+size_flags_vertical = 3
 
 [node name="BoxContainer" type="BoxContainer" parent="HSplitContainer/PreviewNodes/Preview"]
+clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="PreviewScenes" type="SubViewportContainer" parent="HSplitContainer/PreviewNodes/Preview/BoxContainer"]
+clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
 
@@ -156,7 +181,7 @@ render_target_update_mode = 4
 title = "Open a Directory"
 initial_position = 4
 size = Vector2i(800, 600)
-ok_button_text = "选择当前文件夹"
+ok_button_text = "Select Current Folder"
 file_mode = 2
 
 [node name="AcceptDialog" type="AcceptDialog" parent="."]

--- a/addons/Imposter/imposter/scripts/batch_bake.gd
+++ b/addons/Imposter/imposter/scripts/batch_bake.gd
@@ -1,6 +1,8 @@
 @tool
 extends Control
 
+@export var menu_width_percentage: float = 30
+
 @onready var bake_dialog = $BakeFileDialog
 @onready var bake_dir_line = $HSplitContainer/Selects/GridContainer/SelectDir/LineEdit
 @onready var save_dialog = $SaveFileDialog
@@ -21,6 +23,9 @@ var resolution:int=1024
 var frame_size:int=16
 var dilatate_distance:int=32
 var temp_bar:int
+
+func _process(_delta: float) -> void:
+	$HSplitContainer/Selects.custom_minimum_size.x = (EditorInterface.get_editor_viewport_2d().size.x/100) * menu_width_percentage
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/addons/Imposter/imposter/scripts/single_bake.gd
+++ b/addons/Imposter/imposter/scripts/single_bake.gd
@@ -1,6 +1,8 @@
 @tool
 extends Control
 
+@export var menu_width_percentage: float = 30
+
 @onready var file_dialog = $FileDialog
 @onready var warin_dialog = $AcceptDialog
 @onready var save_path_edit = $HSplitContainer/Selects/GridContainer/SaveDir/LineEdit
@@ -26,9 +28,11 @@ var dilatate_distance:int=32
 
 var temp_bar:int
 
+func _process(_delta: float) -> void:
+	$HSplitContainer/Selects.custom_minimum_size.x = (EditorInterface.get_editor_viewport_2d().size.x/100) * menu_width_percentage
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	
 #region godot 4.2+ ,variables can be deleted
 	plugin = EditorPlugin.new()
 	interface = plugin.get_editor_interface()

--- a/addons/Imposter/imposter_plugin.gd
+++ b/addons/Imposter/imposter_plugin.gd
@@ -6,7 +6,6 @@ func _enter_tree():
 	# Initialization of the plugin goes here.
 	add_control_to_bottom_panel(plugin,"imposter")
 
-
 func _exit_tree():
 	# Clean-up of the plugin goes here.
 	remove_control_from_bottom_panel(plugin)


### PR DESCRIPTION
if the viewport size containing the layout of the addon is bigger than 512 x 335, each children will expand to fill the space, it should make this addon usable in notebooks with smaller screens. I also changed the root nodes of SingleBake and BatchBake scenes from a basic Control node to a ScrollView node, so even if the viewport is smaller, you can scroll.
*If there's any changes unrelated to the layout in the editor in this commit, please notify me, these may be specific changes related to my project itself that i forgot to remove.

https://github.com/user-attachments/assets/ab452193-98ee-453e-a62f-1ca5b3c6ebcb

